### PR TITLE
Use io.ReadFull to prevent situation where gzip.Reader doesn't fill t…

### DIFF
--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -422,7 +422,7 @@ func SeekInFile(path string, position *LogstreamLocation) (*os.File, io.Reader, 
 		expectedN int64
 	)
 	if seekPos >= 0 {
-		n, err = reader.Read(buf)
+		n, err = io.ReadFull(reader, buf)
 		expectedN = int64(LINEBUFFERLEN)
 	} else {
 		n, err = reader.Read(buf[-seekPos:])


### PR DESCRIPTION
…he buffer
